### PR TITLE
All exceptions now extend the projec base exception

### DIFF
--- a/src/Event/Factory.php
+++ b/src/Event/Factory.php
@@ -2,6 +2,8 @@
 
 namespace ekinhbayar\GitAmp\Event;
 
+use ekinhbayar\GitAmp\Exception\UnknownEvent;
+
 class Factory
 {
     public function build(string $namespace, array $event): Event
@@ -9,7 +11,7 @@ class Factory
         $eventType = $namespace . '\\' . $event['type'];
 
         if (!$this->isValidType($eventType)) {
-            throw new UnknownEventException($event['type']);
+            throw new UnknownEvent($event['type']);
         }
 
         return new $eventType($event);

--- a/src/Event/UnknownEventException.php
+++ b/src/Event/UnknownEventException.php
@@ -1,5 +1,0 @@
-<?php declare(strict_types=1);
-
-namespace ekinhbayar\GitAmp\Event;
-
-class UnknownEventException extends \Exception {}

--- a/src/Exception/DecodingFailed.php
+++ b/src/Exception/DecodingFailed.php
@@ -1,0 +1,5 @@
+<?php declare(strict_types=1);
+
+namespace ekinhbayar\GitAmp\Exception;
+
+class DecodingFailed extends Exception {}

--- a/src/Exception/Exception.php
+++ b/src/Exception/Exception.php
@@ -1,0 +1,5 @@
+<?php declare(strict_types=1);
+
+namespace ekinhbayar\GitAmp\Exception;
+
+abstract class Exception extends \Exception {}

--- a/src/Exception/RequestFailed.php
+++ b/src/Exception/RequestFailed.php
@@ -1,0 +1,5 @@
+<?php declare(strict_types=1);
+
+namespace ekinhbayar\GitAmp\Exception;
+
+class RequestFailed extends Exception {}

--- a/src/Exception/UnknownEvent.php
+++ b/src/Exception/UnknownEvent.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace ekinhbayar\GitAmp\Exception;
+
+class UnknownEvent extends Exception
+{
+    public function __construct(string $event)
+    {
+        parent::__construct(sprintf('Unknown event (%s) encountered', $event));
+    }
+}

--- a/src/Github/MissingCredentials.php
+++ b/src/Github/MissingCredentials.php
@@ -1,5 +1,0 @@
-<?php declare(strict_types=1);
-
-namespace ekinhbayar\GitAmp\Github;
-
-class MissingCredentials extends \Exception {}

--- a/src/Provider/GitHub.php
+++ b/src/Provider/GitHub.php
@@ -6,6 +6,7 @@ use Amp\Http\Client\HttpClient;
 use Amp\Http\Client\Request;
 use Amp\Http\Client\Response;
 use Amp\Promise;
+use ekinhbayar\GitAmp\Exception\RequestFailed;
 use ekinhbayar\GitAmp\Github\Credentials;
 use ekinhbayar\GitAmp\Response\Factory;
 use Psr\Log\LoggerInterface;
@@ -50,7 +51,7 @@ class GitHub implements Listener
             } catch (\Throwable $e) {
                 $this->logger->error('Failed to send GET request to API endpoint', ['exception' => $e]);
 
-                throw new RequestFailedException('Failed to send GET request to API endpoint', $e->getCode(), $e);
+                throw new RequestFailed('Failed to send GET request to API endpoint', $e->getCode(), $e);
             }
 
             /** @var Response $result */
@@ -63,7 +64,7 @@ class GitHub implements Listener
 
                 $this->logger->critical($message, ['response' => $response]);
 
-                throw new RequestFailedException($message);
+                throw new RequestFailed($message);
             }
 
             return $response;

--- a/src/Provider/RequestFailedException.php
+++ b/src/Provider/RequestFailedException.php
@@ -1,5 +1,0 @@
-<?php declare(strict_types=1);
-
-namespace ekinhbayar\GitAmp\Provider;
-
-class RequestFailedException extends \Exception {}

--- a/src/Response/DecodingFailedException.php
+++ b/src/Response/DecodingFailedException.php
@@ -1,5 +1,0 @@
-<?php declare(strict_types=1);
-
-namespace ekinhbayar\GitAmp\Response;
-
-class DecodingFailedException extends \Exception {}

--- a/src/Response/Results.php
+++ b/src/Response/Results.php
@@ -5,7 +5,8 @@ namespace ekinhbayar\GitAmp\Response;
 use Amp\Http\Client\Response;
 use Amp\Promise;
 use ekinhbayar\GitAmp\Event\Factory as EventFactory;
-use ekinhbayar\GitAmp\Event\UnknownEventException;
+use ekinhbayar\GitAmp\Exception\DecodingFailed;
+use ekinhbayar\GitAmp\Exception\UnknownEvent;
 use ExceptionalJSON\DecodeErrorException;
 use Psr\Log\LoggerInterface;
 use function Amp\call;
@@ -37,7 +38,7 @@ class Results
             } catch (DecodeErrorException $e) {
                 $this->logger->emergency('Failed to decode response body as JSON', ['exception' => $e]);
 
-                throw new DecodingFailedException('Failed to decode response body as JSON', $e->getCode(), $e);
+                throw new DecodingFailed('Failed to decode response body as JSON', $e->getCode(), $e);
             }
 
             foreach ($events as $event) {
@@ -50,7 +51,7 @@ class Results
     {
         try {
             $this->events[] = $this->eventFactory->build($eventNamespace, $event);
-        } catch (UnknownEventException $e) {
+        } catch (UnknownEvent $e) {
             //$this->logger->debug('Unknown event encountered', ['exception' => $e]);
         }
     }

--- a/tests/Event/FactoryTest.php
+++ b/tests/Event/FactoryTest.php
@@ -4,14 +4,14 @@ namespace ekinhbayar\GitAmpTests\Event;
 
 use ekinhbayar\GitAmp\Event\Factory;
 use ekinhbayar\GitAmp\Event\GitHub\CreateEvent;
-use ekinhbayar\GitAmp\Event\UnknownEventException;
+use ekinhbayar\GitAmp\Exception\UnknownEvent;
 use PHPUnit\Framework\TestCase;
 
 class FactoryTest extends TestCase
 {
     public function testBuildThrowsOnUnknownEvent(): void
     {
-        $this->expectException(UnknownEventException::class);
+        $this->expectException(UnknownEvent::class);
 
         (new Factory())->build('Foo', ['type' => 'UnknownEvent']);
     }

--- a/tests/Exception/UnknownEventTest.php
+++ b/tests/Exception/UnknownEventTest.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+namespace ekinhbayar\GitAmpTests\Exception;
+
+use ekinhbayar\GitAmp\Exception\UnknownEvent;
+use PHPUnit\Framework\TestCase;
+
+class UnknownEventTest extends TestCase
+{
+    public function testConstructorFormatsMessageCorrectly(): void
+    {
+        $this->assertSame(
+            'Unknown event (EventName) encountered',
+            (new UnknownEvent('EventName'))->getMessage(),
+        );
+    }
+}

--- a/tests/Provider/GitHubTest.php
+++ b/tests/Provider/GitHubTest.php
@@ -2,14 +2,10 @@
 
 namespace ekinhbayar\GitAmpTests\Provider;
 
-use Amp\ByteStream\Payload;
-use Amp\Http\Client\HttpClient;
 use Amp\Http\Client\HttpClientBuilder;
-use Amp\Http\Client\Response;
-use Amp\ByteStream\InMemoryStream;
 use Amp\Promise;
 use Amp\Success;
-use ekinhbayar\GitAmp\Provider\RequestFailedException;
+use ekinhbayar\GitAmp\Exception\RequestFailed;
 use ekinhbayar\GitAmp\Github\Token;
 use ekinhbayar\GitAmp\Provider\GitHub;
 use ekinhbayar\GitAmp\Response\Factory;
@@ -46,7 +42,7 @@ class GitHubTest extends TestCase
 
         $gitamp = new GitHub($httpClient, $this->credentials, $this->factory, $this->logger);
 
-        $this->expectException(RequestFailedException::class);
+        $this->expectException(RequestFailed::class);
         $this->expectExceptionMessage('Failed to send GET request to API endpoint');
 
         wait($gitamp->listen());
@@ -62,7 +58,7 @@ class GitHubTest extends TestCase
 
         $gitamp = new GitHub($httpClient, $this->credentials, $this->factory, $this->logger);
 
-        $this->expectException(RequestFailedException::class);
+        $this->expectException(RequestFailed::class);
         $this->expectExceptionMessage('A non-200 response status (403 - Forbidden Origin) was encountered');
 
         wait($gitamp->listen());

--- a/tests/Response/ResultsTest.php
+++ b/tests/Response/ResultsTest.php
@@ -9,11 +9,11 @@ use Amp\ByteStream\Payload;
 use Amp\Loop;
 use Amp\Success;
 use ekinhbayar\GitAmp\Event\GitHub\PullRequestEvent;
-use ekinhbayar\GitAmp\Event\UnknownEventException;
+use ekinhbayar\GitAmp\Exception\DecodingFailed;
+use ekinhbayar\GitAmp\Exception\UnknownEvent;
 use PHPUnit\Framework\TestCase;
 use ekinhbayar\GitAmp\Event\Factory;
 use ekinhbayar\GitAmp\Response\Results;
-use ekinhbayar\GitAmp\Response\DecodingFailedException;
 use Psr\Log\LoggerInterface;
 
 class ResultsTest extends TestCase
@@ -71,7 +71,7 @@ class ResultsTest extends TestCase
 
         $response = new Response('2', 200, 'OK', [], $message, new Request('foo'));
 
-        $this->expectException(DecodingFailedException::class);
+        $this->expectException(DecodingFailed::class);
         $this->expectExceptionMessage('Failed to decode response body as JSON');
 
         Loop::run(function () use ($response) {
@@ -98,12 +98,12 @@ class ResultsTest extends TestCase
         $eventFactory
             ->expects($this->once())
             ->method('build')
-            ->willThrowException(new UnknownEventException())
+            ->willThrowException(new UnknownEvent('EventName'))
         ;
 
         Loop::run(function () use ($eventFactory, $response) {
             yield (new Results($eventFactory, $this->logger))
-                ->appendResponse('ekinhbayar\GitAmp\Event\GitHub', $response);
+                ->appendResponse('EventName', $response);
         });
     }
 

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -4,8 +4,8 @@ namespace ekinhbayar\GitAmpTests;
 
 use Amp\Loop;
 use ekinhbayar\GitAmp\Configuration;
+use ekinhbayar\GitAmp\Exception\RequestFailed;
 use ekinhbayar\GitAmp\Github\Token;
-use ekinhbayar\GitAmp\Provider\RequestFailedException;
 use ekinhbayar\GitAmp\Server;
 use ekinhbayar\GitAmp\ServerAddress;
 use League\Uri\Uri;
@@ -16,7 +16,7 @@ class ServerTest extends TestCase
 {
     public function testStartStartsServer(): void
     {
-        $this->expectException(RequestFailedException::class);
+        $this->expectException(RequestFailed::class);
         $this->expectExceptionMessage('A non-200 response status (401 - Unauthorized) was encountered');
 
         $configuration = (new Configuration(new Token('12345')))


### PR DESCRIPTION
Also removed the unused missing creds exception

Fixes the following issue from #47 👍 

- Make exception extend the base project exception instead of the global \Exception